### PR TITLE
copy https://github.com/nixos/nixpkgs/commit/e04cc18f18011471ffe0e693758bfcc0b4cf5393

### DIFF
--- a/scripts/find-tarballs.nix
+++ b/scripts/find-tarballs.nix
@@ -52,7 +52,7 @@ let
   keyDrv = drv: if canEval drv.drvPath then { key = drv.drvPath; value = drv; } else { };
 
   immediateDependenciesOf = drv:
-    concatLists (mapAttrsToList (n: v: derivationsIn v) (removeAttrs drv ["meta" "passthru"]));
+    concatLists (mapAttrsToList (n: v: derivationsIn v) (removeAttrs drv (["meta" "passthru"] ++ optionals (drv?passthru) (attrNames drv.passthru))));
 
   derivationsIn = x:
     if !canEval x then []


### PR DESCRIPTION
> find-tarballs.nix: Avoid all passthru attrs
>
> Avoiding passthru itself was the right direction, but not a
> complete solution. Passthru attributes typically do not contain
> dependencies, but rather extra paths that are not relevant to
> the build itself.
>
> Whether we want to include all (passthru) test dependencies this
> way can be debated, but removing them makes this expression more
> robust.

Should fix https://github.com/nix-community/nixpkgs-swh/issues/5

there have been a few other changes such as getting patch files https://github.com/NixOS/nixpkgs/commits/master/maintainers/scripts/find-tarballs.nix 