### PR TITLE
Update `add-sri.py` script to work with current nixpkgs and Nix

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "nixpkgs": {
-        "branch": "release-21.11",
+        "branch": "nixos-22.11",
         "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b099eaa0e01a45fc3459bbe987c3405c425ef05c",
-        "sha256": "06l6265p21823r092l0nm8fbd60xllnmcw4l2m579pn3japsx332",
+        "rev": "13fdd3945d8a2da5e4afe35d8a629193a9680911",
+        "sha256": "14pic9rpn9wwk1bn0gvkv1v5q1jgnj7avm2f2vlfh2xik1ifhkyh",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/b099eaa0e01a45fc3459bbe987c3405c425ef05c.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/13fdd3945d8a2da5e4afe35d8a629193a9680911.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -31,8 +31,28 @@ let
           if spec ? branch then "refs/heads/${spec.branch}" else
             if spec ? tag then "refs/tags/${spec.tag}" else
               abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!";
+      submodules = if spec ? submodules then spec.submodules else false;
+      submoduleArg =
+        let
+          nixSupportsSubmodules = builtins.compareVersions builtins.nixVersion "2.4" >= 0;
+          emptyArgWithWarning =
+            if submodules == true
+            then
+              builtins.trace
+                (
+                  "The niv input \"${name}\" uses submodules "
+                  + "but your nix's (${builtins.nixVersion}) builtins.fetchGit "
+                  + "does not support them"
+                )
+                {}
+            else {};
+        in
+          if nixSupportsSubmodules
+          then { inherit submodules; }
+          else emptyArgWithWarning;
     in
-      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; };
+      builtins.fetchGit
+        ({ url = spec.repo; inherit (spec) rev; inherit ref; } // submoduleArg);
 
   fetch_local = spec: spec.path;
 

--- a/scripts/add-sri.py
+++ b/scripts/add-sri.py
@@ -21,8 +21,12 @@ with open(sys.argv[1], 'r') as f:
                 hashAlgo = s['outputHashAlgo']
                 hashStr = s['outputHash']
 
+            if (hashAlgo is None or hashAlgo == "") and hashStr != "":
+                s['integrity'] = hashStr
+                continue
+
             result = subprocess.run(
-                ['nix', 'to-sri', '--type', hashAlgo, hashStr],
+                ['nix', 'hash', 'to-sri', '--type', hashAlgo, hashStr],
                 stdout=subprocess.PIPE)
             s['integrity'] = str(result.stdout.rstrip(), 'utf8')
         except TypeError as e:


### PR DESCRIPTION
* Sources can already be using a SRI hash
* `nix hash to-sri` has replaced `nix to-sri`