### PR TITLE
Add a flake with a NixOS module to generate files

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,24 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1738574474,
+        "narHash": "sha256-rvyfF49e/k6vkrRTV4ILrWd92W+nmBDfRYZgctOyolQ=",
+        "path": "/nix/store/096c6m1vzz4zr46lhqc8c1ynwr4zpc0a-source",
+        "rev": "fecfeb86328381268e29e998ddd3ebc70bbd7f7c",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,90 @@
+{
+  description = "nixpkgs-swh";
+
+  outputs = { self, nixpkgs }:
+  let
+    system = "x86_64-linux";
+    pkgs = import nixpkgs {
+      system = "x86_64-linux";
+      overlays = [ self.overlay ];
+    };
+  in {
+    overlay = final: prev: {
+      nixpkgs-swh-generate = let
+        binPath = with final; lib.makeBinPath [ curl nix python3 jq pandoc ];
+      in final.stdenv.mkDerivation {
+        name = "nixpkgs-swh-generate";
+        dontUnpack = true;
+        nativeBuildInputs = [ final.makeWrapper ];
+        installPhase = ''
+          mkdir -p $out/bin
+          cp ${./scripts/generate.sh} $out/bin/nixpkgs-swh-generate
+          substituteInPlace $out/bin/nixpkgs-swh-generate \
+            --replace './scripts/swh-urls.nix' '${./scripts/swh-urls.nix}' \
+            --replace './scripts/add-sri.py' '${./scripts/add-sri.py}' \
+            --replace './scripts/analyze.py' '${./scripts/analyze.py}' \
+            --replace '$PWD/scripts/find-tarballs.nix' '${./scripts/find-tarballs.nix}'
+          wrapProgram $out/bin/nixpkgs-swh-generate \
+            --prefix PATH : ${binPath}
+        '';
+      };
+    };
+
+    packages.x86_64-linux.nixpkgs-swh-generate = pkgs.nixpkgs-swh-generate;
+    defaultPackage.x86_64-linux = pkgs.nixpkgs-swh-generate;
+
+    nixosModules.nixpkgs-swh = { config, pkgs, lib, ... }: let
+      cfg = config.services.nixpkgs-swh;
+      dir = "/var/lib/nixpkgs-swh";
+    in {
+      options = {
+        services.nixpkgs-swh = {
+          enable = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = ''
+              Whether to run the nixpkgs-swh service.
+            '';
+          };
+          testing = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = ''
+              Whether to only evaluate the hello attribute for testing purpose.
+            '';
+          };
+          fqdn = lib.mkOption {
+            type = lib.types.str;
+            description = ''
+              The Nginx vhost FQDN used to serve built files.
+            '';
+          };
+        };
+      };
+      config = {
+        nixpkgs.overlays = [ self.overlay ];
+        systemd.services.nixpkgs-swh = pkgs.lib.mkIf cfg.enable {
+          description = "nixpkgs-swh";
+          wantedBy = [ "multi-user.target" ];
+          restartIfChanged = false;
+          unitConfig.X-StopOnRemoval = false;
+          # Do it every day
+          startAt = "*-*-* 00:00:00";
+          script = ''
+            ${pkgs.nixpkgs-swh-generate}/bin/nixpkgs-swh-generate ${dir} ${if cfg.testing then "true" else "false"} unstable
+          '';
+        };
+        services.nginx.virtualHosts = {
+          "${cfg.fqdn}" = {
+            locations."/" = {
+              root = "${dir}";
+              extraConfig = ''
+                autoindex on;
+              '';
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -5,6 +5,7 @@
 import json
 import sys
 import re
+import datetime
 from urllib.parse import urlparse
 
 with open(sys.argv[1], "r") as read_file:
@@ -62,17 +63,19 @@ for e in sources:
             e['file-type'] = v
             break
 
+today = datetime.date.today()
 
 readme = """
 
-The file [`sources-{release}-full.json`](https://nix-community.github.io/nixpkgs-swh/sources-{release}-full.json)
+The file [`sources-{release}-full.json`](./sources-{release}-full.json)
 has been built from the [nixpkgs revision
 `{revision}`](https://github.com/NixOS/nixpkgs/tree/{revision}).
 This file contains `{sourceNumber}` sources, coming from
 `{hostNumber}` different hosts.
 
-The file [`sources-{release}.json`](https://nix-community.github.io/nixpkgs-swh/sources-{release}.json) is a filtered version which only contains archives. This file is consumed by SWH.
+The file [`sources-{release}.json`](./sources-{release}.json) is a filtered version which only contains archives. This file is consumed by Software Heritage to fill its archive.
 
+Generated the {today}.
 """
 
 sortedHosts = sorted(hosts.items(), key=lambda h: h[1], reverse=True)
@@ -81,7 +84,8 @@ print(readme.format(
     revision=j['revision'],
     release=j['release'],
     sourceNumber=len(sources),
-    hostNumber=len(sortedHosts)))
+    hostNumber=len(sortedHosts),
+    today=today))
 
 
 print("\n#### By host\n")

--- a/scripts/swh-urls.nix
+++ b/scripts/swh-urls.nix
@@ -1,12 +1,12 @@
-{ revision ? null, release ? null, evaluation ? null, timestamp ? null }:
+{ revision ? null, release ? null, evaluation ? null, timestamp ? null, testing ? false, find-tarballs }:
 
 with builtins;
 let
   pkgs = import <nixpkgs> {};
   mirrors = import <nixpkgs/pkgs/build-support/fetchurl/mirrors.nix>;
   expr =  import <nixpkgs/maintainers/scripts/all-tarballs.nix>;
-  urls = import ./find-tarballs.nix {expr = expr;};
-  
+  urls = import find-tarballs {expr = if testing then expr.hello else expr;};
+
   # This is avoid double slashes in urls that make url non valid
   concatUrls = a: b: (pkgs.lib.removeSuffix "/" a) + "/" + (pkgs.lib.removePrefix "/" b);
 
@@ -20,7 +20,7 @@ let
   in if isMirrorUrl
   then [ url ]
   else map (r: concatUrls r path) resolvedUrls;
-  
+
   # Transform the url list to swh format
   toSwh = s: {
     inherit (s) postFetch outputHashMode outputHashAlgo outputHash;


### PR DESCRIPTION
We previously used a buildkite agent to run scripts. However, this agent has been removed by nix-community admins.

Instead of running a buildkite agent and using GitHub to serve produced artefacts, it seems we could run scripts thanks to a systemd periodic task and serve artefacts with Nginx: https://github.com/nix-community/infra/issues/445

In this PR, a flake exposes the nixpkgs-swh-generate program and a NixOS module running this program each days.

I'm currently testing this PR on my server (it only generates the list of sources for the hello attribute): http://nixpkgs-swh.abesis.fr

The URL used by the Software fetcher will have to be updated (it is currently https://nix-community.github.io/nixpkgs-swh/sources-unstable-full.json).