### PR TITLE
Move to nixos

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,0 @@
-steps:
-  - label: "Publish sources.json"
-    branches: "master testing"
-    command: "scripts/publish.sh"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 This repository contains scripts to generate a
-[`sources.json`](https://nix-community.github.io/nixpkgs-swh/sources-unstable.json)
+[`sources.json`](https://nixpkgs-swh.nixos.org/sources-unstable.json)
 file ingested by [Software
 Heritage](https://www.softwareheritage.org/). This file contains the
 URL of tarballs required to build
@@ -8,7 +8,7 @@ Buildkite CI generates it each day by picking a Nixpkgs commit built
 by [Hydra](https://hydra.nixos.org/project/nixpkgs).
 
 A basic analysis of this file is also generated and published
-[here](https://nix-community.github.io/nixpkgs-swh).
+[here](https://nixpkgs-swh.nixos.org/README.md).
 
 # Locally generate files
 


### PR DESCRIPTION
The `sources.json` is now generated by the NixOS infra and published at https://nixpkgs-swh.nixos.org/
